### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,4 +339,4 @@ For ready-to-use plugin templates in Rust and Go, see [TEMPLATES.md](./TEMPLATES
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyper-mcp-rs/hyper-mcp&type=Date)](https://www.star-history.com/#hyper-mcp-rs/hyper-mcp&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyper-mcp-rs/hyper-mcp&type=Date)](https://star-history.dera.page/#hyper-mcp-rs/hyper-mcp&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken: the image no longer renders because the old provider is limited by GitHub's stargazer API restrictions. This PR points the chart at the replacement service so it displays correctly again. The change is limited to the Star History section and touches no other part of the project.